### PR TITLE
Plat 383 improve boottime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.7.0
+
+- [PLAT-383] Improve boottime by lazy loading extension
+
 ## 0.6.0
 
 - [PLAT-183] Ruby 3.0, Rails 7 and coveralls github action

--- a/lib/activerecord_null_object.rb
+++ b/lib/activerecord_null_object.rb
@@ -4,4 +4,6 @@ require 'activerecord_null_object/version'
 require 'activerecord_null_object/null_object'
 require 'activerecord_null_object/null_object_support'
 
-ActiveRecord::Base.send :include, ActiveRecordNullObject::NullObjectSupport
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Base.send :include, ActiveRecordNullObject::NullObjectSupport
+end


### PR DESCRIPTION
### WHY

Improve boot time reported by bumbler by lazy loading the extension

```
236.82  activerecord_null_object
```

```
  3.33  activerecord_null_object
```